### PR TITLE
Add minimal Flask RAG app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Cattle RAG Flask Demo
+
+This project demonstrates a minimal Flask application with user authentication, knowledge management and a very small RAG (Retrieval Augmented Generation) workflow.
+
+Run the application:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+from flask import Flask, render_template
+from config import init_app
+from models import db
+from auth import bp as auth_bp
+from knowledge import bp as knowledge_bp
+from rag import bp as rag_bp
+from upload import bp as upload_bp
+
+
+def create_app():
+    app = Flask(__name__)
+    init_app(app)
+    db.init_app(app)
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(knowledge_bp)
+    app.register_blueprint(rag_bp)
+    app.register_blueprint(upload_bp)
+
+    @app.route('/')
+    def index():
+        return render_template('index.html')
+
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True)

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,41 @@
+from flask import Blueprint, request, redirect, render_template, url_for, flash
+from models import db, User
+from utils import hash_password, verify_password, login_user, logout_user
+
+
+bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+
+@bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            flash('User already exists')
+        else:
+            user = User(username=username, password_hash=hash_password(password))
+            db.session.add(user)
+            db.session.commit()
+            flash('Registration successful')
+            return redirect(url_for('auth.login'))
+    return render_template('register.html')
+
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and verify_password(user.password_hash, password):
+            login_user(user.id)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@bp.route('/logout')
+def logout():
+    logout_user()
+    return redirect(url_for('index'))

--- a/config.py
+++ b/config.py
@@ -1,0 +1,11 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///app.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', 'data/user_data')
+
+
+def init_app(app):
+    app.config.from_object(Config)

--- a/embeddings/bge_m3.py
+++ b/embeddings/bge_m3.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+
+def embed_text(text: str):
+    # Placeholder embedding using character ord values
+    vec = np.frombuffer(text.encode('utf-8'), dtype=np.uint8).astype(float)
+    if vec.size == 0:
+        return np.zeros(1)
+    return vec / np.linalg.norm(vec)

--- a/knowledge.py
+++ b/knowledge.py
@@ -1,0 +1,28 @@
+from flask import Blueprint, request, render_template, redirect, url_for
+from models import db, Knowledge
+from utils import current_user
+
+
+bp = Blueprint('knowledge', __name__, url_prefix='/knowledge')
+
+
+@bp.route('/')
+def list_knowledge():
+    user_id = current_user()
+    items = Knowledge.query.filter_by(user_id=user_id).all() if user_id else []
+    return render_template('knowledge_list.html', items=items)
+
+
+@bp.route('/new', methods=['GET', 'POST'])
+def new_knowledge():
+    user_id = current_user()
+    if not user_id:
+        return redirect(url_for('auth.login'))
+    if request.method == 'POST':
+        title = request.form['title']
+        content = request.form['content']
+        item = Knowledge(user_id=user_id, title=title, content=content)
+        db.session.add(item)
+        db.session.commit()
+        return redirect(url_for('knowledge.list_knowledge'))
+    return render_template('knowledge_edit.html')

--- a/models.py
+++ b/models.py
@@ -1,0 +1,26 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+
+db = SQLAlchemy()
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+
+class Knowledge(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    title = db.Column(db.String(200))
+    content = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class Chunk(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    knowledge_id = db.Column(db.Integer, db.ForeignKey('knowledge.id'), nullable=False)
+    text = db.Column(db.Text)
+    vector = db.Column(db.PickleType)

--- a/rag.py
+++ b/rag.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, request, render_template
+from embeddings.bge_m3 import embed_text
+from vector_db.faiss_index import search_vectors
+
+
+bp = Blueprint('rag', __name__, url_prefix='/rag')
+
+
+@bp.route('/query', methods=['GET', 'POST'])
+def query():
+    answer = None
+    if request.method == 'POST':
+        text = request.form['text']
+        vector = embed_text(text)
+        docs = search_vectors(vector)
+        answer = '\n'.join(docs)
+    return render_template('rag_query.html', answer=answer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-SQLAlchemy
+Werkzeug
+numpy

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,1 @@
+console.log('main loaded');

--- a/static/rag.js
+++ b/static/rag.js
@@ -1,0 +1,4 @@
+function submitQuery() {
+  const form = document.getElementById('queryForm');
+  form.submit();
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 20px; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Cattle RAG{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <script src="{{ url_for('static', filename='main.js') }}"></script>
+</head>
+<body>
+  <header>
+    <h1>Cattle RAG</h1>
+    <nav>
+      <a href="{{ url_for('index') }}">Home</a> |
+      <a href="{{ url_for('auth.login') }}">Login</a> |
+      <a href="{{ url_for('auth.register') }}">Register</a>
+    </nav>
+  </header>
+  <hr>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h2>Dashboard</h2>
+<p>Welcome user {{ user_id }}.</p>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<p>Welcome to Cattle RAG demo.</p>
+{% endblock %}

--- a/templates/knowledge_edit.html
+++ b/templates/knowledge_edit.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}New Knowledge{% endblock %}
+{% block content %}
+<form method="post">
+  <input type="text" name="title" placeholder="Title">
+  <textarea name="content" placeholder="Content"></textarea>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/knowledge_list.html
+++ b/templates/knowledge_list.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}Knowledge{% endblock %}
+{% block content %}
+<h2>Your Knowledge</h2>
+<ul>
+  {% for k in items %}
+  <li>{{ k.title }}</li>
+  {% else %}
+  <li>No knowledge entries.</li>
+  {% endfor %}
+</ul>
+<a href="{{ url_for('knowledge.new_knowledge') }}">Add New</a>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<form method="post">
+  <input type="text" name="username" placeholder="Username">
+  <input type="password" name="password" placeholder="Password">
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/rag_query.html
+++ b/templates/rag_query.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}RAG Query{% endblock %}
+{% block content %}
+<form method="post" id="queryForm">
+  <input type="text" name="text" placeholder="Ask something">
+  <button type="submit">Ask</button>
+</form>
+{% if answer %}
+<h3>Answer</h3>
+<pre>{{ answer }}</pre>
+{% endif %}
+{% endblock %}

--- a/templates/rag_result.html
+++ b/templates/rag_result.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}RAG Result{% endblock %}
+{% block content %}
+<h3>Result</h3>
+<pre>{{ result }}</pre>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<form method="post">
+  <input type="text" name="username" placeholder="Username">
+  <input type="password" name="password" placeholder="Password">
+  <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}Upload{% endblock %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="file">
+  <button type="submit">Upload</button>
+</form>
+{% endblock %}

--- a/upload.py
+++ b/upload.py
@@ -1,0 +1,19 @@
+import os
+from flask import Blueprint, request, render_template, current_app, redirect, url_for
+from werkzeug.utils import secure_filename
+
+
+bp = Blueprint('upload', __name__, url_prefix='/upload')
+
+
+@bp.route('/', methods=['GET', 'POST'])
+def upload_file():
+    if request.method == 'POST':
+        f = request.files['file']
+        if f.filename:
+            filename = secure_filename(f.filename)
+            path = os.path.join(current_app.config['UPLOAD_FOLDER'], filename)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            f.save(path)
+            return redirect(url_for('upload.upload_file'))
+    return render_template('upload.html')

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,22 @@
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask import session
+
+
+def hash_password(password: str) -> str:
+    return generate_password_hash(password)
+
+
+def verify_password(pw_hash: str, password: str) -> bool:
+    return check_password_hash(pw_hash, password)
+
+
+def login_user(user_id: int):
+    session['user_id'] = user_id
+
+
+def logout_user():
+    session.pop('user_id', None)
+
+
+def current_user():
+    return session.get('user_id')

--- a/vector_db/faiss_index.py
+++ b/vector_db/faiss_index.py
@@ -1,0 +1,19 @@
+import numpy as np
+from typing import List
+
+# Simple in-memory "vector DB" for demo
+_vectors = []
+_docs = []
+
+
+def add_vector(vector: np.ndarray, doc: str):
+    _vectors.append(vector)
+    _docs.append(doc)
+
+
+def search_vectors(vector: np.ndarray, topk: int = 3) -> List[str]:
+    if not _vectors:
+        return []
+    sims = [float(np.dot(v, vector) / (np.linalg.norm(v) * np.linalg.norm(vector))) for v in _vectors]
+    idxs = np.argsort(sims)[-topk:][::-1]
+    return [_docs[i] for i in idxs]


### PR DESCRIPTION
## Summary
- implement basic Flask app with blueprints for auth, knowledge, rag and upload
- add SQLAlchemy models and helper utilities
- create minimal HTML templates and static assets
- provide very small vector embedding/search placeholders
- add README and requirements

## Testing
- `python -m py_compile app.py auth.py config.py knowledge.py models.py rag.py upload.py utils.py embeddings/bge_m3.py vector_db/faiss_index.py`
- `pip install -q -r requirements.txt`
- `python app.py` (started server successfully, then stopped)

------
https://chatgpt.com/codex/tasks/task_e_68434d0ae18c832a8a7eb78e62192e28