### PR TITLE
Add minimal Flask RAG implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Cattle RAG Flask
+
+This project provides a minimal demonstration of a Retrieval-Augmented Generation (RAG) web application using Flask.  The repository contains blueprints for authentication, knowledge management and a very small example RAG endpoint.  It is intentionally lightweight so it can run in limited environments.
+
+To start the application locally:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+The database uses SQLite by default and will be created automatically on first run.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template
+from config import Config
+from models import db
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+
+    db.init_app(app)
+
+    from auth import auth_bp
+    from knowledge import knowledge_bp
+    from rag import rag_bp
+    from upload import upload_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(knowledge_bp, url_prefix='/knowledge')
+    app.register_blueprint(rag_bp, url_prefix='/rag')
+    app.register_blueprint(upload_bp, url_prefix='/upload')
+
+    @app.route('/')
+    def index():
+        return render_template('index.html')
+
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+
+if __name__ == '__main__':
+    create_app().run(debug=True)

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, request, jsonify, session, redirect, render_template
+from models import db, User
+from utils import hash_password, verify_password
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        data = request.form if request.form else request.json
+        username = data.get('username')
+        password = data.get('password')
+        if not username or not password:
+            return jsonify({'error': 'Invalid input'}), 400
+        if User.query.filter_by(username=username).first():
+            return jsonify({'error': 'User exists'}), 400
+        user = User(username=username, password_hash=hash_password(password))
+        db.session.add(user)
+        db.session.commit()
+        return redirect('/login')
+    return render_template('register.html')
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        data = request.form if request.form else request.json
+        username = data.get('username')
+        password = data.get('password')
+        user = User.query.filter_by(username=username).first()
+        if user and verify_password(user.password_hash, password):
+            session['user_id'] = user.id
+            return redirect('/')
+        return jsonify({'error': 'Invalid credentials'}), 400
+    return render_template('login.html')
+
+
+@auth_bp.route('/logout')
+def logout():
+    session.clear()
+    return redirect('/login')

--- a/config.py
+++ b/config.py
@@ -1,0 +1,9 @@
+import os
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "devkey")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URI") or \
+        "sqlite:///" + os.path.join(BASE_DIR, "app.db")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/embeddings/bge_m3.py
+++ b/embeddings/bge_m3.py
@@ -1,0 +1,6 @@
+"""Placeholder for embedding utilities."""
+
+
+def embed_text(text: str):
+    """Return a dummy embedding for the provided text."""
+    return [float(len(text))]

--- a/knowledge.py
+++ b/knowledge.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, request, jsonify, session, render_template
+from models import db, Knowledge
+from utils import login_required
+
+knowledge_bp = Blueprint('knowledge', __name__)
+
+
+@knowledge_bp.route('/', methods=['GET'])
+@login_required
+def list_knowledge():
+    records = Knowledge.query.all()
+    return render_template('knowledge_list.html', knowledges=records)
+
+
+@knowledge_bp.route('/create', methods=['GET', 'POST'])
+@login_required
+def create_knowledge():
+    if request.method == 'POST':
+        title = request.form.get('title')
+        content = request.form.get('content')
+        if not title or not content:
+            return jsonify({'error': 'invalid input'}), 400
+        record = Knowledge(title=title, content=content, user_id=session['user_id'])
+        db.session.add(record)
+        db.session.commit()
+        return jsonify({'id': record.id})
+    return render_template('knowledge_edit.html')
+
+
+@knowledge_bp.route('/<int:knowledge_id>', methods=['GET'])
+@login_required
+def get_knowledge(knowledge_id):
+    record = Knowledge.query.get_or_404(knowledge_id)
+    return jsonify({'id': record.id, 'title': record.title, 'content': record.content})
+
+
+@knowledge_bp.route('/<int:knowledge_id>', methods=['PUT'])
+@login_required
+def update_knowledge(knowledge_id):
+    record = Knowledge.query.get_or_404(knowledge_id)
+    data = request.json
+    record.title = data.get('title', record.title)
+    record.content = data.get('content', record.content)
+    db.session.commit()
+    return jsonify({'message': 'updated'})
+
+
+@knowledge_bp.route('/<int:knowledge_id>', methods=['DELETE'])
+@login_required
+def delete_knowledge(knowledge_id):
+    record = Knowledge.query.get_or_404(knowledge_id)
+    db.session.delete(record)
+    db.session.commit()
+    return jsonify({'message': 'deleted'})

--- a/models.py
+++ b/models.py
@@ -1,0 +1,23 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# SQLAlchemy instance used across the application
+# It will be initialized with the app in app.create_app
+
+db = SQLAlchemy()
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+class Knowledge(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+
+class Chunk(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    knowledge_id = db.Column(db.Integer, db.ForeignKey('knowledge.id'))
+    content = db.Column(db.Text, nullable=False)
+    embedding = db.Column(db.PickleType)

--- a/rag.py
+++ b/rag.py
@@ -1,0 +1,25 @@
+from flask import Blueprint, request, jsonify, render_template
+from models import Knowledge
+
+rag_bp = Blueprint('rag', __name__)
+
+
+def simple_search(query: str):
+    """Very naive search through knowledge content."""
+    return Knowledge.query.filter(Knowledge.content.contains(query)).all()
+
+
+@rag_bp.route('/')
+def rag_page():
+    """Render a tiny page for making RAG queries."""
+    return render_template('rag_query.html')
+
+
+@rag_bp.route('/query', methods=['POST'])
+def rag_query():
+    data = request.json
+    query = data.get('query', '')
+    results = simple_search(query)
+    context = "\n".join([k.content for k in results])
+    answer = f"[Dummy answer] {query}"
+    return jsonify({'answer': answer, 'context': context})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.3
+Flask-SQLAlchemy>=3.0

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,1 @@
+// General page scripts placeholder

--- a/static/rag.js
+++ b/static/rag.js
@@ -1,0 +1,10 @@
+async function sendQuery() {
+  const q = document.getElementById('query').value;
+  const resp = await fetch('/rag/query', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({query: q})
+  });
+  const data = await resp.json();
+  document.getElementById('answer').innerText = data.answer;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,4 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Cattle RAG{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<header>
+  <h1>Cattle RAG Flask</h1>
+  <nav>
+    <a href="/">Home</a> |
+    <a href="/knowledge/">Knowledge</a> |
+    <a href="/rag">RAG</a>
+  </nav>
+</header>
+<section>
+{% block content %}{% endblock %}
+</section>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<p>Dashboard placeholder.</p>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<p>Welcome to the Cattle RAG demo.</p>
+<p><a href="/rag">Try the RAG demo</a></p>
+{% endblock %}

--- a/templates/knowledge_edit.html
+++ b/templates/knowledge_edit.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post">
+  <input type="text" name="title" placeholder="Title"><br>
+  <textarea name="content" placeholder="Content"></textarea><br>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/knowledge_list.html
+++ b/templates/knowledge_list.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Knowledge List</h2>
+<ul>
+{% for k in knowledges %}
+  <li>{{ k.title }}</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post">
+  <label>Username: <input type="text" name="username"></label><br>
+  <label>Password: <input type="password" name="password"></label><br>
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/rag_query.html
+++ b/templates/rag_query.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>RAG Query</h2>
+<input type="text" id="query" placeholder="Ask something">
+<button onclick="sendQuery()">Send</button>
+<p id="answer"></p>
+<script src="{{ url_for('static', filename='rag.js') }}"></script>
+{% endblock %}

--- a/templates/rag_result.html
+++ b/templates/rag_result.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<p id="answer">{{ answer }}</p>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post">
+  <label>Username: <input type="text" name="username"></label><br>
+  <label>Password: <input type="password" name="password"></label><br>
+  <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="file">
+  <button type="submit">Upload</button>
+</form>
+{% endblock %}

--- a/upload.py
+++ b/upload.py
@@ -1,0 +1,18 @@
+import os
+from flask import Blueprint, request, jsonify
+
+upload_bp = Blueprint('upload', __name__)
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'data')
+
+
+@upload_bp.route('/', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return jsonify({'error': 'no file'}), 400
+    file = request.files['file']
+    filename = file.filename
+    if not filename:
+        return jsonify({'error': 'empty filename'}), 400
+    save_path = os.path.join(UPLOAD_FOLDER, filename)
+    file.save(save_path)
+    return jsonify({'filename': filename})

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,25 @@
+from werkzeug.security import generate_password_hash, check_password_hash
+from functools import wraps
+from flask import session, redirect, url_for
+
+
+def hash_password(password: str) -> str:
+    """Return a hashed version of the password."""
+    return generate_password_hash(password)
+
+
+def verify_password(pw_hash: str, password: str) -> bool:
+    """Verify a password against its hash."""
+    return check_password_hash(pw_hash, password)
+
+
+def login_required(view):
+    """Simple decorator to ensure a user is logged in."""
+
+    @wraps(view)
+    def wrapped_view(**kwargs):
+        if not session.get("user_id"):
+            return redirect(url_for("auth.login"))
+        return view(**kwargs)
+
+    return wrapped_view

--- a/vector_db/faiss_index.py
+++ b/vector_db/faiss_index.py
@@ -1,0 +1,14 @@
+"""Minimal FAISS index placeholder."""
+
+class SimpleIndex:
+    def __init__(self):
+        self._items = []
+
+    def add(self, embedding, metadata):
+        self._items.append((embedding, metadata))
+
+    def search(self, embedding, top_k=5):
+        # very naive search by length difference
+        scored = [ (abs(e[0][0] - embedding[0]), meta) for e, meta in self._items ]
+        scored.sort(key=lambda x: x[0])
+        return [meta for _, meta in scored[:top_k]]


### PR DESCRIPTION
## Summary
- implement minimal Flask app and config
- add SQLAlchemy models and blueprints for auth, knowledge, rag, and upload
- provide simple templates and static assets
- document how to run the demo

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile app.py auth.py knowledge.py rag.py upload.py utils.py config.py models.py embeddings/bge_m3.py vector_db/faiss_index.py`
- `pytest -q`
- `python3 app.py` *(started and stopped to confirm server boots)*

------
https://chatgpt.com/codex/tasks/task_e_68434d9b76d8832a8d6540a7e6e7cee8