### PR TITLE
Add basic HTML templates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Cattle RAG{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="{{ url_for('index') }}">Home</a> |
+            <a href="{{ url_for('login') }}">Login</a> |
+            <a href="{{ url_for('register') }}">Register</a> |
+            <a href="{{ url_for('dashboard') }}">Dashboard</a> |
+            <a href="{{ url_for('knowledge_list') }}">Knowledge</a> |
+            <a href="{{ url_for('rag_query') }}">RAG</a> |
+            <a href="{{ url_for('upload') }}">Upload</a>
+        </nav>
+    </header>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+    <footer>
+        <p>&copy; 2024 Cattle RAG</p>
+    </footer>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1>User Dashboard</h1>
+<p>Welcome, {{ user.username }}!</p>
+<ul>
+    <li><a href="{{ url_for('knowledge_list') }}">Manage Knowledge</a></li>
+    <li><a href="{{ url_for('upload') }}">Upload Data</a></li>
+    <li><a href="{{ url_for('rag_query') }}">Ask the RAG</a></li>
+</ul>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<h1>Welcome to Cattle RAG</h1>
+<p>This project demonstrates a simple RAG workflow with Flask.</p>
+<p><a href="{{ url_for('rag_query') }}">Start querying</a></p>
+{% endblock %}

--- a/templates/knowledge_edit.html
+++ b/templates/knowledge_edit.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}Edit Knowledge{% endblock %}
+{% block content %}
+<h1>{% if item %}Edit{% else %}Add{% endif %} Knowledge</h1>
+<form method="post" action="{{ url_for('knowledge_save') }}">
+    <input type="hidden" name="id" value="{{ item.id if item }}">
+    <label for="title">Title:</label>
+    <input type="text" id="title" name="title" value="{{ item.title if item }}" required>
+    <label for="content">Content:</label>
+    <textarea id="content" name="content" rows="5" required>{{ item.content if item }}</textarea>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/knowledge_list.html
+++ b/templates/knowledge_list.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Knowledge List{% endblock %}
+{% block content %}
+<h1>Knowledge Entries</h1>
+<a href="{{ url_for('knowledge_edit') }}">Add New</a>
+<table>
+    <tr><th>Title</th><th>Actions</th></tr>
+    {% for item in knowledge %}
+    <tr>
+        <td>{{ item.title }}</td>
+        <td>
+            <a href="{{ url_for('knowledge_edit', id=item.id) }}">Edit</a> |
+            <a href="{{ url_for('knowledge_delete', id=item.id) }}">Delete</a>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+<form method="post" action="{{ url_for('login') }}">
+    <label for="username">Username:</label>
+    <input type="text" name="username" id="username" required>
+    <label for="password">Password:</label>
+    <input type="password" name="password" id="password" required>
+    <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/rag_query.html
+++ b/templates/rag_query.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}RAG Query{% endblock %}
+{% block content %}
+<h1>Ask a Question</h1>
+<form method="post" action="{{ url_for('rag_query') }}">
+    <label for="question">Question:</label>
+    <input type="text" id="question" name="question" required>
+    <button type="submit">Submit</button>
+</form>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='rag.js') }}"></script>
+{% endblock %}

--- a/templates/rag_result.html
+++ b/templates/rag_result.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}RAG Result{% endblock %}
+{% block content %}
+<h1>Result</h1>
+<p><strong>Question:</strong> {{ question }}</p>
+<p><strong>Answer:</strong></p>
+<p>{{ answer }}</p>
+{% if sources %}
+<h3>Sources</h3>
+<ul>
+    {% for src in sources %}
+    <li>{{ src }}</li>
+    {% endfor %}
+</ul>
+{% endif %}
+<a href="{{ url_for('rag_query') }}">Ask another</a>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h1>Register</h1>
+<form method="post" action="{{ url_for('register') }}">
+    <label for="username">Username:</label>
+    <input type="text" name="username" id="username" required>
+    <label for="email">Email:</label>
+    <input type="email" name="email" id="email" required>
+    <label for="password">Password:</label>
+    <input type="password" name="password" id="password" required>
+    <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Upload{% endblock %}
+{% block content %}
+<h1>Upload Data</h1>
+<form method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data">
+    <label for="file">Select file:</label>
+    <input type="file" id="file" name="file" required>
+    <button type="submit">Upload</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create starter HTML templates for site navigation, forms, and RAG pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68434dafadb4832a8be29bb18bdd1fba