### PR TITLE
Add base set of Jinja templates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Cattle RAG{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script src="{{ url_for('static', filename='main.js') }}" defer></script>
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="{{ url_for('index') }}">Home</a>
+            {% if session.get('user_id') %}
+                <a href="{{ url_for('dashboard') }}">Dashboard</a>
+                <a href="{{ url_for('auth.logout') }}">Logout</a>
+            {% else %}
+                <a href="{{ url_for('auth.login') }}">Login</a>
+                <a href="{{ url_for('auth.register') }}">Register</a>
+            {% endif %}
+        </nav>
+    </header>
+    <main>
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            <ul class="flash-messages">
+            {% for msg in messages %}
+              <li>{{ msg }}</li>
+            {% endfor %}
+            </ul>
+          {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </main>
+    <footer>
+        <p>&copy; 2024 Cattle RAG</p>
+    </footer>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1>Dashboard</h1>
+<ul>
+    <li><a href="{{ url_for('knowledge.list') }}">Manage Knowledge</a></li>
+    <li><a href="{{ url_for('upload.index') }}">Upload Files</a></li>
+    <li><a href="{{ url_for('rag.query') }}">Ask with RAG</a></li>
+</ul>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<h1>Welcome to Cattle RAG</h1>
+<p>This demo showcases retrieval augmented generation.</p>
+<a href="{{ url_for('rag.query') }}">Start Asking</a>
+{% endblock %}

--- a/templates/knowledge_edit.html
+++ b/templates/knowledge_edit.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Edit Knowledge{% endblock %}
+{% block content %}
+<h1>{{ 'Edit' if knowledge else 'New' }} Knowledge</h1>
+<form method="post">
+    <label>Title</label>
+    <input type="text" name="title" value="{{ knowledge.title if knowledge else '' }}" required>
+    <label>Content</label>
+    <textarea name="content" rows="10" required>{{ knowledge.content if knowledge else '' }}</textarea>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/knowledge_list.html
+++ b/templates/knowledge_list.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Knowledge List{% endblock %}
+{% block content %}
+<h1>Knowledge List</h1>
+<table>
+    <tr><th>Title</th><th>Actions</th></tr>
+    {% for item in knowledges %}
+    <tr>
+        <td>{{ item.title }}</td>
+        <td>
+            <a href="{{ url_for('knowledge.edit', knowledge_id=item.id) }}">Edit</a>
+            <form action="{{ url_for('knowledge.delete', knowledge_id=item.id) }}" method="post" style="display:inline;">
+                <button type="submit">Delete</button>
+            </form>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+<a href="{{ url_for('knowledge.new') }}">Add Knowledge</a>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+    <label>Email</label>
+    <input type="email" name="email" required>
+    <label>Password</label>
+    <input type="password" name="password" required>
+    <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/rag_query.html
+++ b/templates/rag_query.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}RAG Query{% endblock %}
+{% block content %}
+<h1>RAG Query</h1>
+<form id="rag-form" method="post">
+    <textarea name="query" rows="3" placeholder="Enter your question" required>{{ request.form.query }}</textarea>
+    <button type="submit">Ask</button>
+</form>
+<div id="rag-result">
+    {% if result %}
+        <h2>Result</h2>
+        <p>{{ result }}</p>
+    {% endif %}
+</div>
+<script src="{{ url_for('static', filename='rag.js') }}"></script>
+{% endblock %}

--- a/templates/rag_result.html
+++ b/templates/rag_result.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}RAG Result{% endblock %}
+{% block content %}
+<h1>RAG Result</h1>
+<p>{{ result }}</p>
+<a href="{{ url_for('rag.query') }}">Back</a>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h1>Register</h1>
+<form method="post">
+    <label>Email</label>
+    <input type="email" name="email" required>
+    <label>Password</label>
+    <input type="password" name="password" required>
+    <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}Upload Files{% endblock %}
+{% block content %}
+<h1>Upload Files</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="file" name="file" required>
+    <button type="submit">Upload</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- populate `templates/` with basic HTML pages
- provide main layout and simple forms for login and register
- add stub pages for knowledge management and RAG features

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68434dc1ba58832aa7ccb36edc2ab1ad